### PR TITLE
Enhance button focus visibility

### DIFF
--- a/getIterator.js
+++ b/getIterator.js
@@ -1,0 +1,11 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+exports.default = function (coll) {
+    return coll[Symbol.iterator] && coll[Symbol.iterator]();
+};
+
+module.exports = exports["default"];


### PR DESCRIPTION
Improve keyboard accessibility by increasing the contrast and thickness of button focus indicators to meet WCAG guidance. This replaces the faint box-shadow with a 2px solid outline on :focus-visible and updates token colours so focus is clearly visible without altering normal hover styles.